### PR TITLE
Fix AttributeError in log(): call pcapdroid.log(), not do_log()

### DIFF
--- a/app/src/main/python/mitm.py
+++ b/app/src/main/python/mitm.py
@@ -184,7 +184,7 @@ def stop():
 # Entrypoint: logs a message to console/PCAPdroid
 def log(lvl: int, msg: str):
     if pcapdroid:
-        pcapdroid.do_log(msg, lvl)
+        pcapdroid.log(msg, lvl)
 
 def checkCertificate():
     if os.path.exists(CA_CERT_PATH):


### PR DESCRIPTION
The module-level `log()` entrypoint in `mitm.py` calls `pcapdroid.do_log(msg, lvl)`, but the `PCAPdroid` class (in `pcapdroid.py`) only defines `log()` and `log_warn()` — there is no `do_log`. So any message routed through this entrypoint (e.g. a logged warning) raises:

```
AttributeError: 'PCAPdroid' object has no attribute 'do_log'
    at <python>.mitm.log(mitm.py:187)
    at com.pcapdroid.mitm.MitmService.log_w(MitmService.java)
    at com.pcapdroid.mitm.MitmService.handleMessage(MitmService.java)
```

which crashes `mitmdump`. Because the service respawns into the same path, capture stops working once anything triggers a warning (a TLS handshake failure is enough).

The same file already calls `pcapdroid.log(...)` / `pcapdroid.log_warn(...)` correctly from the mitmproxy log hook, so this just points the entrypoint at the same method. Signatures match — `PCAPdroid.log(self, msg, lvl=Log.INFO)` accepts `(msg, lvl)`.

```diff
 def log(lvl: int, msg: str):
     if pcapdroid:
-        pcapdroid.do_log(msg, lvl)
+        pcapdroid.log(msg, lvl)
```

Found while debugging a downstream build; reproduced on Android with the current `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)