### PR TITLE
Do not drop responses that carry trailers

### DIFF
--- a/app/src/main/python/pcapdroid.py
+++ b/app/src/main/python/pcapdroid.py
@@ -56,6 +56,24 @@ def ip_version(ip: str) -> int:
         return 4
     return addr.version
 
+def assemble_response_with_trailers(response) -> bytes:
+    """Serialise a response whose trailers would otherwise make assemble_response() raise.
+
+    assemble_body() refuses to emit trailers unless the message is chunked, because that is the
+    only legal HTTP/1 framing for them. HTTP/2 and HTTP/3 responses routinely carry trailers --
+    gRPC reports its status there -- and never carry transfer-encoding, so serialising one raises
+    ValueError, the response hook dies, and the response is never dumped at all.
+
+    Serialising a chunked copy keeps the trailers, and costs the receiver nothing: genuinely
+    chunked HTTP/1 responses already reach it unchanged.
+    """
+    if response.trailers and "chunked" not in response.headers.get(
+            "transfer-encoding", "").lower():
+        response = response.copy()
+        response.headers["transfer-encoding"] = "chunked"
+    return assemble_response(response)
+
+
 def transport_to_ipproto(transport_protocol: str) -> int:
     return IPPROTO_UDP if transport_protocol == "udp" else IPPROTO_TCP
 
@@ -197,7 +215,7 @@ class PCAPdroid:
                 self.send_message(flow.response.timestamp_start, flow.client_conn, flow.server_conn,
                                   MsgType.JS_INJECTED, flow.js_injector_scripts.encode("ascii"))
 
-            data = self.checkPayload(flow, assemble_response(flow.response), req=False)
+            data = self.checkPayload(flow, assemble_response_with_trailers(flow.response), req=False)
             if data:
                 self.send_message(flow.response.timestamp_start, flow.client_conn, flow.server_conn, MsgType.HTTP_REPLY, data)
 


### PR DESCRIPTION
Any response carrying trailers is currently dropped from the dump entirely, with only an addon error in the log to indicate it happened.

## Cause

`response()` serialises with `assemble_response()`, and mitmproxy's `assemble_body()` refuses to emit trailers unless the message is chunked — the only legal HTTP/1 framing for them:

```python
else:
    if trailers:
        raise ValueError(
            "Sending HTTP/1.1 trailer headers requires transfer-encoding: chunked"
        )
```

The `ValueError` propagates out of the `response` hook, so `send_message()` is never reached and the response is never dumped:

```
File ".../pcapdroid.py", line 200, in response
File ".../mitmproxy/net/http/http1/assemble.py", line 23, in assemble_response
File ".../mitmproxy/net/http/http1/assemble.py", line 48, in assemble_body
ValueError: Sending HTTP/1.1 trailer headers requires transfer-encoding: chunked
[Addon error: Sending HTTP/1.1 trailer headers requires transfer-encoding: chunked]
```

The triggering combination is not unusual: HTTP/2 and HTTP/3 responses commonly carry trailers — gRPC reports its status there — and never carry `transfer-encoding`, since that header does not exist in those versions. So the responses most likely to hit this are ordinary modern app traffic.

## Impact

Measured on an Android capture of a single Google Maps session: **5 of 40 responses carried a `grpc-status` trailer**, and every one was absent from the dump. The requests were captured, so the missing halves look like responses that never arrived rather than responses that were discarded.

## Fix

Serialise a chunked copy when trailers are present, so the trailers are kept instead of discarded. This costs consumers nothing — genuinely chunked HTTP/1 responses already pass through unchanged, so any consumer already handles chunked framing.

An alternative would be to strip the trailers and keep the original framing, which is a smaller change but throws away the gRPC status. Happy to switch to that if you would rather not alter framing.

## Verification

On a Pixel 8 (Android 17) capturing a Google Maps session: the `ValueError` goes from recurring throughout the session to zero, addon errors to zero, and the trailer-carrying responses appear in the dump with their trailers intact.

Found while capturing HTTP/3 traffic through `--mode wireguard` in [PetriDroid](https://github.com/kasnder/petridroid), which builds this addon with a small patch set. Reproduces against upstream HEAD (c39e885) independently of those patches.