### PR TITLE
Handle HTTP/2 and HTTP/3 trailer headers in message assembly

### DIFF
--- a/app/src/main/python/pcapdroid.py
+++ b/app/src/main/python/pcapdroid.py
@@ -25,7 +25,11 @@ import time
 import mitmproxy
 import traceback
 from mitmproxy import http, ctx
-from mitmproxy.net.http.http1.assemble import assemble_request, assemble_response
+from mitmproxy.net.http.http1.assemble import (
+    assemble_request_head,
+    assemble_response_head,
+    assemble_body,
+)
 from mitmproxy.proxy import server_hooks
 from mitmproxy.log import LogEntry
 from enum import Enum
@@ -58,6 +62,27 @@ def ip_version(ip: str) -> int:
 
 def transport_to_ipproto(transport_protocol: str) -> int:
     return IPPROTO_UDP if transport_protocol == "udp" else IPPROTO_TCP
+
+def _assemble_message(message, head: bytes) -> bytes:
+    data = message.data
+    if data.trailers and "chunked" not in data.headers.get("transfer-encoding", "").lower():
+        # HTTP/2 and HTTP/3 carry trailers without transfer-encoding: chunked, which
+        # mitmproxy's assemble_body() refuses to serialize. Fold the trailer headers
+        # into the regular header block, producing a valid HTTP/1.1 message
+        head = head[:-2] + bytes(data.trailers) + b"\r\n"
+        return head + data.content
+
+    return head + b"".join(assemble_body(data.headers, [data.content], data.trailers))
+
+def assemble_request(request) -> bytes:
+    if request.data.content is None:
+        raise ValueError("Cannot assemble flow with missing content")
+    return _assemble_message(request, assemble_request_head(request))
+
+def assemble_response(response) -> bytes:
+    if response.data.content is None:
+        raise ValueError("Cannot assemble flow with missing content")
+    return _assemble_message(response, assemble_response_head(response))
 
 class AddonOpts:
     def __init__(self, dump_client, dump_keylog, short_payload):


### PR DESCRIPTION
mitmproxy's assemble_body() raises "Sending HTTP/1.1 trailer headers requires transfer-encoding: chunked" for HTTP/2 and HTTP/3 responses, which carry trailers without a transfer-encoding header.

Wrap the http1 head assemblers with a local assemble_request/assemble_response that folds the trailers into the regular header block, producing a valid HTTP/1.1 message. The alternative would be injecting a fake transfer-encoding header, but that would leak to the API caller and create issues with the PCAPdroid HTTP reassembly logic.