### PR TITLE
Apply --set options in the embedded mitmdump runner

### DIFF
--- a/app/src/main/python/mitm.py
+++ b/app/src/main/python/mitm.py
@@ -143,6 +143,10 @@ def run(fd: int, jenabled_addons, addons_home: str, dump_client: bool,
                 print("mitmdump " + mitm_args)
                 parser = cmdline.mitmdump(opts)
                 args = parser.parse_args(mitm_args.split())
+                # mitmproxy.tools.main.run() applies --set via opts.set(*args.setoptions,
+                # defer=True) before process_options(); this embedded runner never did, so any
+                # addon-registered --set option silently kept its default.
+                opts.set(*args.setoptions, defer=True)
                 process_options(parser, opts, args)
                 checkCertificate()
 


### PR DESCRIPTION
mitm.py's run() parses `--set key=value` into `args.setoptions` but never applies it — process_options() only copies argparse dest names that already match a registered Option, and `setoptions` isn't one. Stock mitmproxy applies it via `opts.set(*args.setoptions, defer=True)` in `mitmproxy.tools.main.run()`; this embedded copy dropped that line.

Any addon relying on a custom `--set` option silently gets its default instead. Fixes it by adding the same call before `process_options()`.